### PR TITLE
Add minimum widths for components

### DIFF
--- a/src/Components/Header/Header.css
+++ b/src/Components/Header/Header.css
@@ -5,8 +5,9 @@
   width: 100vw;
   justify-content: center;
   align-items: center;
-  border: solid 3px black;
+  border-bottom: solid 3px black;
   background: transparent;
+  overflow-wrap: normal;
 }
 
 .teams-button-container {
@@ -15,6 +16,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  min-width: 340px;
 }
 
 .page-title-container {
@@ -23,6 +25,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  min-width: 340px;
 }
 
 .cards-button-container {
@@ -31,6 +34,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  min-width: 340px;
 }
 
 .title {

--- a/src/Components/Home/Home.css
+++ b/src/Components/Home/Home.css
@@ -5,6 +5,8 @@
   background: linear-gradient(black, white); 
   background-image: url(../../images/home-image.png);
   background-size: cover;
+  min-width: 870px;
+  min-height: 720px;
 }
 
 .home-header {
@@ -26,6 +28,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: center;
+  min-width: 870px;
 }
 
 .left-side {
@@ -58,6 +61,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  min-width: 300px;
 }
 
 .teams-link:hover {
@@ -76,6 +80,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  min-width: 300px;
 }
 
 .saved-link:hover {

--- a/src/Components/MyCards/MyCards.css
+++ b/src/Components/MyCards/MyCards.css
@@ -18,7 +18,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  
+  min-width: 700px;
 }
 
 .user-cards {
@@ -26,6 +26,7 @@
   width: 100vw;
   background-image: url(../../images/kobe.png);
   background-attachment: fixed;
+  min-width: 700px;
 }
 
 .page-header {

--- a/src/Components/PlayerCard/PlayerCard.css
+++ b/src/Components/PlayerCard/PlayerCard.css
@@ -10,6 +10,8 @@
   background: white;
   font-family: cursive;
   box-shadow: 3px 3px 3px black;
+  min-width: 141px;
+  min-height: 302px;
 }
 
 .player-card:hover {

--- a/src/Components/ViewRoster/ViewRoster.css
+++ b/src/Components/ViewRoster/ViewRoster.css
@@ -13,6 +13,7 @@
   width: 100vw;
   background-image: url(../../images/court.png);
   background-attachment: fixed;
+  min-width: 700px;
 }
 
 .loading-message {

--- a/src/Components/ViewTeams/ViewTeams.css
+++ b/src/Components/ViewTeams/ViewTeams.css
@@ -18,6 +18,7 @@ a:active {
   height: 250vh;
   width: 100vw;
   background-image: url(../../images/court.png);
+  min-width: 700px;
   background-attachment: fixed;
 }
 
@@ -29,6 +30,7 @@ a:active {
   flex-direction: row;
   justify-content: space-evenly;
   margin-top: 10em;
+  min-width: 650px;
 }
 
 .team-card {


### PR DESCRIPTION
In this PR I added minimum width and height with overflow scroll. This should allow for mobile users to still operate and navigate around the App as needed.